### PR TITLE
使用 `font-display: swap` 策略

### DIFF
--- a/.github/workflows/webfont-subsetter.py
+++ b/.github/workflows/webfont-subsetter.py
@@ -177,7 +177,7 @@ def prepare_font_subset(source_file, css_font_family_name, output_parent=None, j
                 "@font-face {\n",
                 "  font-family: '{}';\n".format(css_font_family_name),
                 "  font-style: normal;\n",
-                "  font-display: block;\n",
+                "  font-display: swap;\n",
                 "  src: url('./{}') format('woff2');\n".format(out_file),
                 "  unicode-range: {}\n".format(unicode),
                 "}\n"


### PR DESCRIPTION
目前 `block` 策略，字型檔案加載時網頁顯示為一片空白；而使用 `swap` 策略，在此期間則會看到設備已有字型顯示的內容，待網路加載完成，再顯示為 I.Ming 字型；後者相比前者，交互體驗更好。

Google Fonts 默認使用的策略也是 `swap`。